### PR TITLE
Add Date & Time Confirmation Form for Places

### DIFF
--- a/src/app/modules/chat/lib/confirm-form-schema.ts
+++ b/src/app/modules/chat/lib/confirm-form-schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const ConfirmFormSchema = z.object({
+  startDate: z
+    .date({
+      required_error: "Start date is required",
+    })
+    .refine((date) => date > new Date(), {
+      message: "Start date must be in the future",
+    }),
+  endDate: z
+    .date({
+      required_error: "End date is required",
+    })
+    .refine((date) => date > new Date(), {
+      message: "End date must be in the future",
+    }),
+});

--- a/src/app/modules/chat/ui/components/confirm-dialog.tsx
+++ b/src/app/modules/chat/ui/components/confirm-dialog.tsx
@@ -1,0 +1,59 @@
+import { LikedPlace } from "@/app/modules/map/store/liked-place-store";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useLikedPlaces } from "@/app/modules/map/store/liked-place-store";
+import { IconType } from "@/app/modules/map/store/liked-place-store";
+import { Button } from "@/components/ui/button";
+
+interface PlaceCardProps {
+  place: LikedPlace;
+  activePlacesTab: "confirmed" | "candidates";
+}
+
+export function ConfirmDialog({ place, activePlacesTab }: PlaceCardProps) {
+  const setIconType = useLikedPlaces((state) => state.setIconType);
+  const getIconType = useLikedPlaces((state) => state.getIconType);
+  const getMarker = useLikedPlaces((state) => state.getMarker);
+
+  const toggleConfirmed = (place: LikedPlace) => {
+    const placeId = place.placeId;
+    const isConfirmed = getIconType(placeId) === IconType.STAR;
+    setIconType(placeId, isConfirmed ? IconType.HEART : IconType.STAR);
+    const marker = getMarker(placeId);
+
+    const img = document.createElement("img");
+    img.src = !isConfirmed ? "/star.png" : "/heart.png";
+    img.style.width = "36px";
+    img.style.height = "36px";
+
+    if (marker) marker.content = img;
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger onClick={(e) => e.stopPropagation()}>
+        <Button className="h-[28px]">
+          {activePlacesTab === "confirmed" ? "Remove" : "Confirm"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{place.name}</DialogTitle>
+          <DialogDescription asChild>
+            <div>
+              <div>Hi</div>
+              <Button onClick={() => toggleConfirmed(place)}>confirm</Button>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/modules/chat/ui/components/confirm-dialog.tsx
+++ b/src/app/modules/chat/ui/components/confirm-dialog.tsx
@@ -1,5 +1,4 @@
 import { LikedPlace } from "@/app/modules/map/store/liked-place-store";
-
 import {
   Dialog,
   DialogContent,
@@ -10,14 +9,13 @@ import {
 } from "@/components/ui/dialog";
 import { useLikedPlaces } from "@/app/modules/map/store/liked-place-store";
 import { IconType } from "@/app/modules/map/store/liked-place-store";
-import { Button } from "@/components/ui/button";
+import { ConfirmForm } from "./confirm-form";
 
 interface PlaceCardProps {
   place: LikedPlace;
-  activePlacesTab: "confirmed" | "candidates";
 }
 
-export function ConfirmDialog({ place, activePlacesTab }: PlaceCardProps) {
+export function ConfirmDialog({ place }: PlaceCardProps) {
   const setIconType = useLikedPlaces((state) => state.setIconType);
   const getIconType = useLikedPlaces((state) => state.getIconType);
   const getMarker = useLikedPlaces((state) => state.getMarker);
@@ -36,21 +34,29 @@ export function ConfirmDialog({ place, activePlacesTab }: PlaceCardProps) {
     if (marker) marker.content = img;
   };
 
+  if (getIconType(place.placeId) === IconType.STAR) {
+    return (
+      <div
+        className="h-[28px] rounded-xl bg-black text-white hover:bg-gray-500 text-center w-[80px] flex items-center justify-center hover:cursor-pointer"
+        onClick={() => toggleConfirmed(place)}
+      >
+        Remove
+      </div>
+    );
+  }
+
   return (
     <Dialog>
-      <DialogTrigger onClick={(e) => e.stopPropagation()}>
-        <Button className="h-[28px]">
-          {activePlacesTab === "confirmed" ? "Remove" : "Confirm"}
-        </Button>
+      <DialogTrigger onClick={(e) => e.stopPropagation()} asChild>
+        <div className="h-[28px] rounded-xl bg-black text-white hover:bg-gray-500 text-center w-[80px] flex items-center justify-center hover:cursor-pointer">
+          Confirm
+        </div>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{place.name}</DialogTitle>
           <DialogDescription asChild>
-            <div>
-              <div>Hi</div>
-              <Button onClick={() => toggleConfirmed(place)}>confirm</Button>
-            </div>
+            <ConfirmForm onToggleConfirmed={toggleConfirmed} place={place} />
           </DialogDescription>
         </DialogHeader>
       </DialogContent>

--- a/src/app/modules/chat/ui/components/confirm-form.tsx
+++ b/src/app/modules/chat/ui/components/confirm-form.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/popover";
 import { toast } from "sonner";
 import { ConfirmFormSchema } from "../../lib/confirm-form-schema";
-import { useForm } from "react-hook-form";
+import { useForm, UseFormReturn } from "react-hook-form";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { LikedPlace } from "@/app/modules/map/store/liked-place-store";
 
@@ -116,7 +116,7 @@ interface DateTimePickerFieldProps {
     type: "hour" | "minute" | "ampm",
     value: string
   ) => void;
-  form: any;
+  form: UseFormReturn<z.infer<typeof ConfirmFormSchema>>;
 }
 
 function DateTimePickerField({

--- a/src/app/modules/chat/ui/components/confirm-form.tsx
+++ b/src/app/modules/chat/ui/components/confirm-form.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CalendarIcon } from "lucide-react";
+import { format } from "date-fns";
+import { z } from "zod";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { toast } from "sonner";
+import { ConfirmFormSchema } from "../../lib/confirm-form-schema";
+import { useForm } from "react-hook-form";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { LikedPlace } from "@/app/modules/map/store/liked-place-store";
+
+interface ConfirmFormProps {
+  place: LikedPlace;
+  onToggleConfirmed: (place: LikedPlace) => void;
+}
+
+export function ConfirmForm({ place, onToggleConfirmed }: ConfirmFormProps) {
+  const form = useForm<z.infer<typeof ConfirmFormSchema>>({
+    resolver: zodResolver(ConfirmFormSchema),
+  });
+
+  function onSubmit(data: z.infer<typeof ConfirmFormSchema>) {
+    toast.success("Confirmed!");
+    onToggleConfirmed(place);
+    console.log(data);
+  }
+
+  function handleDateSelect(
+    field: "startDate" | "endDate",
+    date: Date | undefined
+  ) {
+    if (date) {
+      form.setValue(field, date);
+    }
+  }
+
+  function handleTimeChange(
+    field: "startDate" | "endDate",
+    type: "hour" | "minute" | "ampm",
+    value: string
+  ) {
+    const currentDate = form.getValues(field) || new Date();
+    let newDate = new Date(currentDate);
+
+    if (type === "hour") {
+      const hour = parseInt(value, 10);
+      newDate.setHours(newDate.getHours() >= 12 ? hour + 12 : hour);
+    } else if (type === "minute") {
+      newDate.setMinutes(parseInt(value, 10));
+    } else if (type === "ampm") {
+      const hours = newDate.getHours();
+      if (value === "AM" && hours >= 12) {
+        newDate.setHours(hours - 12);
+      } else if (value === "PM" && hours < 12) {
+        newDate.setHours(hours + 12);
+      }
+    }
+
+    form.setValue(field, newDate);
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="mt-4 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DateTimePickerField
+          name="startDate"
+          label="Enter Start Date & Time (12h)"
+          onDateSelect={handleDateSelect}
+          onTimeChange={handleTimeChange}
+          form={form}
+        />
+        <DateTimePickerField
+          name="endDate"
+          label="Enter End Date & Time (12h)"
+          onDateSelect={handleDateSelect}
+          onTimeChange={handleTimeChange}
+          form={form}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  );
+}
+
+interface DateTimePickerFieldProps {
+  name: "startDate" | "endDate";
+  label: string;
+  onDateSelect: (
+    field: "startDate" | "endDate",
+    date: Date | undefined
+  ) => void;
+  onTimeChange: (
+    field: "startDate" | "endDate",
+    type: "hour" | "minute" | "ampm",
+    value: string
+  ) => void;
+  form: any;
+}
+
+function DateTimePickerField({
+  name,
+  label,
+  onDateSelect,
+  onTimeChange,
+  form,
+}: DateTimePickerFieldProps) {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="flex flex-col">
+          <FormLabel>{label}</FormLabel>
+          <Popover modal>
+            <PopoverTrigger asChild>
+              <FormControl>
+                <Button
+                  variant={"outline"}
+                  className={cn(
+                    "w-full pl-3 text-left font-normal",
+                    !field.value && "text-muted-foreground"
+                  )}
+                >
+                  {field.value ? (
+                    format(field.value, "MM/dd/yyyy hh:mm aa")
+                  ) : (
+                    <span>MM/DD/YYYY hh:mm aa</span>
+                  )}
+                  <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                </Button>
+              </FormControl>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0">
+              <div className="sm:flex">
+                <Calendar
+                  mode="single"
+                  selected={field.value}
+                  onSelect={(date) => onDateSelect(name, date)}
+                  initialFocus
+                />
+                <div className="flex flex-col sm:flex-row sm:h-[300px] divide-y sm:divide-y-0 sm:divide-x">
+                  <ScrollArea className="w-64 sm:w-auto">
+                    <div className="flex sm:flex-col p-2">
+                      {Array.from({ length: 12 }, (_, i) => i + 1)
+                        .reverse()
+                        .map((hour) => (
+                          <Button
+                            key={hour}
+                            size="icon"
+                            variant={
+                              field.value &&
+                              field.value.getHours() % 12 === hour % 12
+                                ? "default"
+                                : "ghost"
+                            }
+                            className="sm:w-full shrink-0 aspect-square"
+                            onClick={() =>
+                              onTimeChange(name, "hour", hour.toString())
+                            }
+                          >
+                            {hour}
+                          </Button>
+                        ))}
+                    </div>
+                    <ScrollBar orientation="horizontal" className="sm:hidden" />
+                  </ScrollArea>
+                  <ScrollArea className="w-64 sm:w-auto">
+                    <div className="flex sm:flex-col p-2">
+                      {Array.from({ length: 12 }, (_, i) => i * 5).map(
+                        (minute) => (
+                          <Button
+                            key={minute}
+                            size="icon"
+                            variant={
+                              field.value && field.value.getMinutes() === minute
+                                ? "default"
+                                : "ghost"
+                            }
+                            className="sm:w-full shrink-0 aspect-square"
+                            onClick={() =>
+                              onTimeChange(name, "minute", minute.toString())
+                            }
+                          >
+                            {minute.toString().padStart(2, "0")}
+                          </Button>
+                        )
+                      )}
+                    </div>
+                    <ScrollBar orientation="horizontal" className="sm:hidden" />
+                  </ScrollArea>
+                  <ScrollArea className="">
+                    <div className="flex sm:flex-col p-2">
+                      {["AM", "PM"].map((ampm) => (
+                        <Button
+                          key={ampm}
+                          size="icon"
+                          variant={
+                            field.value &&
+                            ((ampm === "AM" && field.value.getHours() < 12) ||
+                              (ampm === "PM" && field.value.getHours() >= 12))
+                              ? "default"
+                              : "ghost"
+                          }
+                          className="sm:w-full shrink-0 aspect-square"
+                          onClick={() => onTimeChange(name, "ampm", ampm)}
+                        >
+                          {ampm}
+                        </Button>
+                      ))}
+                    </div>
+                  </ScrollArea>
+                </div>
+              </div>
+            </PopoverContent>
+          </Popover>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/app/modules/chat/ui/components/place-card.tsx
+++ b/src/app/modules/chat/ui/components/place-card.tsx
@@ -8,7 +8,7 @@ interface PlaceCardProps {
   activePlacesTab: "confirmed" | "candidates";
 }
 
-export function PlaceCard({ place, activePlacesTab }: PlaceCardProps) {
+export function PlaceCard({ place }: PlaceCardProps) {
   const getTypeIcon = (type?: string) => {
     switch (type) {
       case "식사":
@@ -68,10 +68,7 @@ export function PlaceCard({ place, activePlacesTab }: PlaceCardProps) {
                   <span>Added by {place.addedBy}</span>
                 </div>
 
-                <ConfirmDialog
-                  place={place}
-                  activePlacesTab={activePlacesTab}
-                />
+                <ConfirmDialog place={place} />
               </div>
             </div>
           </div>

--- a/src/app/modules/chat/ui/components/place-card.tsx
+++ b/src/app/modules/chat/ui/components/place-card.tsx
@@ -1,21 +1,7 @@
-import {
-  IconType,
-  LikedPlace,
-  useLikedPlaces,
-} from "@/app/modules/map/store/liked-place-store";
-import { useMapStore } from "@/app/modules/map/store/map-store";
-import { Button } from "@/components/ui/button";
+import { LikedPlace } from "@/app/modules/map/store/liked-place-store";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  Badge,
-  Bed,
-  Bus,
-  Camera,
-  Clock,
-  MapPin,
-  Star,
-  Utensils,
-} from "lucide-react";
+import { Bed, Bus, Camera, Clock, MapPin, Star, Utensils } from "lucide-react";
+import { ConfirmDialog } from "./confirm-dialog";
 
 interface PlaceCardProps {
   place: LikedPlace;
@@ -23,12 +9,6 @@ interface PlaceCardProps {
 }
 
 export function PlaceCard({ place, activePlacesTab }: PlaceCardProps) {
-  const map = useMapStore((state) => state.map);
-  const likedPlaces = useLikedPlaces((state) => state.likedPlaces);
-  const setIconType = useLikedPlaces((state) => state.setIconType);
-  const getIconType = useLikedPlaces((state) => state.getIconType);
-  const getMarker = useLikedPlaces((state) => state.getMarker);
-
   const getTypeIcon = (type?: string) => {
     switch (type) {
       case "식사":
@@ -42,20 +22,6 @@ export function PlaceCard({ place, activePlacesTab }: PlaceCardProps) {
       default:
         return <MapPin className="h-4 w-4" />;
     }
-  };
-
-  const toggleConfirmed = (place: LikedPlace) => {
-    const placeId = place.placeId;
-    const isConfirmed = getIconType(placeId) === IconType.STAR;
-    setIconType(placeId, isConfirmed ? IconType.HEART : IconType.STAR);
-    const marker = getMarker(placeId);
-
-    const img = document.createElement("img");
-    img.src = !isConfirmed ? "/star.png" : "/heart.png";
-    img.style.width = "36px";
-    img.style.height = "36px";
-
-    if (marker) marker.content = img;
   };
 
   return (
@@ -101,12 +67,11 @@ export function PlaceCard({ place, activePlacesTab }: PlaceCardProps) {
                   <Clock className="h-3 w-3 mr-1" />
                   <span>Added by {place.addedBy}</span>
                 </div>
-                <div
-                  className="h-6 text-xs border rounded-md px-2 flex items-center justify-center cursor-pointer hover:bg-blue-500 hover:text-white transition-colors bg-black text-white"
-                  onClick={() => toggleConfirmed(place)}
-                >
-                  {activePlacesTab === "confirmed" ? "Remove" : "Confirm"}
-                </div>
+
+                <ConfirmDialog
+                  place={place}
+                  activePlacesTab={activePlacesTab}
+                />
               </div>
             </div>
           </div>

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,165 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }


### PR DESCRIPTION
### 📃 Changes
* Created a new confirmation form component that allows users to schedule visits to places with precise date and time selection
* Implemented dual date-time picker fields for both start and end times
* Added form validation using React Hook Form with Zod schema
* Built a custom time picker with a 12-hour format interface (hours, minutes, AM/PM)
### 📌 Important
* Form integrates with the existing liked places system to convert candidate places into confirmed places
* When a place is confirmed, it will appear in the confirmed tab and can be added to the travel itinerary
* Form handles proper time formatting and conversion between 12-hour display and internal 24-hour storage
### 🫨 Considerations
* The time picker currently offers minute selection in 5-minute increments - we might want to add more granular options in the future
* We may want to add validation to prevent users from setting end dates earlier than start dates
* Consider adding a place type selector (restaurant, attraction, accommodation, etc.) in a future update
### 🎇 Screenshots
![스크린샷 2025-05-15 오후 8 34 45](https://github.com/user-attachments/assets/54ed2e46-1aac-4b8c-86b6-af96c5f0242f)
![스크린샷 2025-05-15 오후 8 34 49](https://github.com/user-attachments/assets/eeaa7ef0-0fdb-4082-a201-fadbd7519c9a)

### 💫 ETC
* This component is part of the travel planning flow, helping users create more structured itineraries
* Future enhancements could include duration calculation, conflict detection with existing plans, and integration with calendar export functionality
* A bug occurred when using a Popover inside a Dialog, causing it not to function properly.
This was resolved by setting the modal property to true on the root Popover component and stopping event propagation.
    * Reference – https://github.com/shadcn-ui/ui/issues/1511