### PR TITLE
Support AI message requests via button and enhance message styling by type

### DIFF
--- a/src/app/modules/chat/types/index.ts
+++ b/src/app/modules/chat/types/index.ts
@@ -92,4 +92,5 @@ export interface ChatMessage {
   senderName?: string;
   text?: string;
   sendAt?: string;
+  imgUrl?: string;
 }

--- a/src/app/modules/chat/ui/chat.tsx
+++ b/src/app/modules/chat/ui/chat.tsx
@@ -30,37 +30,42 @@ export default function Chat() {
     middlePanelVisible,
     rightPanelVisible,
     setPanelVisibility,
-    togglePanel
+    togglePanel,
   } = usePanelVisibilityStore();
 
   // 패널 가시성에 따라 동적으로 defaultWidth 값 계산
-  const { defaultLeftWidth, defaultMiddleWidth, defaultRightWidth } = useMemo(() => {
-    // 활성화된 패널 수 계산
-    const visibleCount = [leftPanelVisible, middlePanelVisible, rightPanelVisible].filter(Boolean).length;
+  const { defaultLeftWidth, defaultMiddleWidth, defaultRightWidth } =
+    useMemo(() => {
+      // 활성화된 패널 수 계산
+      const visibleCount = [
+        leftPanelVisible,
+        middlePanelVisible,
+        rightPanelVisible,
+      ].filter(Boolean).length;
 
-    if (visibleCount === 1) {
-      // 하나의 패널만 보이는 경우, 해당 패널의 너비를 100%로 설정
-      return {
-        defaultLeftWidth: leftPanelVisible ? 100 : 0,
-        defaultMiddleWidth: middlePanelVisible ? 100 : 0,
-        defaultRightWidth: rightPanelVisible ? 100 : 0
-      };
-    } else if (visibleCount === 2) {
-      // 두 개의 패널이 보이는 경우, 각각 50%씩 할당
-      return {
-        defaultLeftWidth: leftPanelVisible ? 50 : 0,
-        defaultMiddleWidth: middlePanelVisible ? 50 : 0,
-        defaultRightWidth: rightPanelVisible ? 50 : 0
-      };
-    } else {
-      // 세 개의 패널이 모두 보이는 경우 또는 모두 숨겨진 경우(예외 처리)
-      return {
-        defaultLeftWidth: 56,
-        defaultMiddleWidth: 24,
-        defaultRightWidth: 20
-      };
-    }
-  }, [leftPanelVisible, middlePanelVisible, rightPanelVisible]);
+      if (visibleCount === 1) {
+        // 하나의 패널만 보이는 경우, 해당 패널의 너비를 100%로 설정
+        return {
+          defaultLeftWidth: leftPanelVisible ? 100 : 0,
+          defaultMiddleWidth: middlePanelVisible ? 100 : 0,
+          defaultRightWidth: rightPanelVisible ? 100 : 0,
+        };
+      } else if (visibleCount === 2) {
+        // 두 개의 패널이 보이는 경우, 각각 50%씩 할당
+        return {
+          defaultLeftWidth: leftPanelVisible ? 50 : 0,
+          defaultMiddleWidth: middlePanelVisible ? 50 : 0,
+          defaultRightWidth: rightPanelVisible ? 50 : 0,
+        };
+      } else {
+        // 세 개의 패널이 모두 보이는 경우 또는 모두 숨겨진 경우(예외 처리)
+        return {
+          defaultLeftWidth: 56,
+          defaultMiddleWidth: 24,
+          defaultRightWidth: 20,
+        };
+      }
+    }, [leftPanelVisible, middlePanelVisible, rightPanelVisible]);
 
   const [activeLeftTab, setActiveLeftTab] = useState("map");
   const [activePlacesTab, setActivePlacesTab] =
@@ -83,15 +88,17 @@ export default function Chat() {
   };
 
   // 패널 토글 핸들러 - 스토어의 함수 사용
-  const toggleLeftPanel = () => togglePanel('left');
-  const toggleMiddlePanel = () => togglePanel('middle');
-  const toggleRightPanel = () => togglePanel('right');
+  const toggleLeftPanel = () => togglePanel("left");
+  const toggleMiddlePanel = () => togglePanel("middle");
+  const toggleRightPanel = () => togglePanel("right");
 
-  const handleSendMessage = () => {
+  const handleSendMessage = (type: "chat" | "aiRequest") => {
     if (!inputValue.trim()) return;
 
+    console.log(type);
+
     const userMessage: ChatMessage = {
-      type: "chat",
+      type,
       senderName: currentUser,
       text: inputValue,
       sendAt: new Date().toISOString(),
@@ -105,7 +112,7 @@ export default function Chat() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey && !isComposing) {
       e.preventDefault();
-      handleSendMessage();
+      handleSendMessage("chat");
     }
   };
 
@@ -119,12 +126,12 @@ export default function Chat() {
         eventData.type === "Food"
           ? "#F59E0B"
           : eventData.type === "Tour"
-            ? "#88C58F"
-            : eventData.type === "Stay"
-              ? "#60A5FA"
-              : eventData.type === "Move"
-                ? "#A78BFA"
-                : "#94A3B8",
+          ? "#88C58F"
+          : eventData.type === "Stay"
+          ? "#60A5FA"
+          : eventData.type === "Move"
+          ? "#A78BFA"
+          : "#94A3B8",
     };
 
     setScheduleItems((prev) => [...prev, newEvent]);
@@ -147,7 +154,9 @@ export default function Chat() {
       {/* Main Content with Resizable Layout */}
       <div className="w-full mt-14">
         <ResizableLayout
-          key={`panels-${leftPanelVisible ? 1 : 0}-${middlePanelVisible ? 1 : 0}-${rightPanelVisible ? 1 : 0}`}
+          key={`panels-${leftPanelVisible ? 1 : 0}-${
+            middlePanelVisible ? 1 : 0
+          }-${rightPanelVisible ? 1 : 0}`}
           leftContent={
             <LeftPanel
               activeTab={activeLeftTab}
@@ -170,7 +179,7 @@ export default function Chat() {
               messages={chatMessages}
               inputValue={inputValue}
               onInputChange={setInputValue}
-              onSendMessage={handleSendMessage}
+              onAIRequest={handleSendMessage}
               onKeyDown={handleKeyDown}
               onSetIsComposing={(value) => setIsComposing(value)}
             />

--- a/src/app/modules/chat/ui/chat.tsx
+++ b/src/app/modules/chat/ui/chat.tsx
@@ -95,8 +95,6 @@ export default function Chat() {
   const handleSendMessage = (type: "chat" | "aiRequest") => {
     if (!inputValue.trim()) return;
 
-    console.log(type);
-
     const userMessage: ChatMessage = {
       type,
       senderName: currentUser,

--- a/src/app/modules/chat/ui/components/chat-message-card.tsx
+++ b/src/app/modules/chat/ui/components/chat-message-card.tsx
@@ -17,8 +17,8 @@ interface ChatMessageCardProps {
 export const ChatMessageCard = ({ message }: ChatMessageCardProps) => {
   const accessToken = useAuthStore((s) => s.accessToken);
   if (!accessToken) return null;
-  const currentUserName = parseJwt(accessToken!).name;
-  const currentUserImageUrl = parseJwt(accessToken!).imageUrl;
+  const currentUserName = parseJwt(accessToken).name;
+  const currentUserImageUrl = parseJwt(accessToken).imageUrl;
   const sendAt = new Date(message.sendAt!);
 
   const [hovered, setHovered] = useState(false);
@@ -41,9 +41,13 @@ export const ChatMessageCard = ({ message }: ChatMessageCardProps) => {
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
-          {message.type === "chat" && currentUserImageUrl ? (
+          {message.type === "chat" ? (
             <AvatarImage
-              src={currentUserImageUrl}
+              src={
+                message.senderName === currentUserName
+                  ? currentUserImageUrl
+                  : message.imgUrl
+              }
               alt="User Avatar"
               className="h-8 w-8"
             />

--- a/src/app/modules/chat/ui/components/chat-message-card.tsx
+++ b/src/app/modules/chat/ui/components/chat-message-card.tsx
@@ -81,11 +81,13 @@ export const ChatMessageCard = ({ message }: ChatMessageCardProps) => {
             </div>
           )}
           <Card
-            className={`${
+            className={`${cn(
               message.type === "aiResponse"
-                ? "bg-secondary/20 border-secondary/30"
+                ? "bg-blue-400 border-secondary/30"
+                : message.type === "aiRequest"
+                ? "bg-yellow-200 border-accent/30"
                 : ""
-            }`}
+            )}`}
           >
             <CardContent className="p-3 text-sm">{message.text}</CardContent>
           </Card>

--- a/src/app/modules/chat/ui/right-panel.tsx
+++ b/src/app/modules/chat/ui/right-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useEffect } from "react";
-import { MessageSquare, Send, Info, InfoIcon } from "lucide-react";
+import { MessageSquare, Info, InfoIcon, BotIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ChatMessage } from "../types";
@@ -86,12 +86,12 @@ export const RightPanel = ({
             disabled={!inputValue.trim()}
             className="bg-accent text-accent-foreground hover:bg-accent/90"
           >
-            <Send className="h-5 w-5" />
+            <BotIcon className="h-5 w-5" />
           </Button>
         </div>
         <div className="flex items-center mt-2 text-xs text-muted-foreground">
           <Info className="h-3 w-3 mr-1" />
-          <span>Try using #recommend to get AI suggestions</span>
+          <span>Press Enter to send a message, click the button to ask AI</span>
         </div>
       </div>
     </div>

--- a/src/app/modules/chat/ui/right-panel.tsx
+++ b/src/app/modules/chat/ui/right-panel.tsx
@@ -11,7 +11,7 @@ interface RightPanelProps {
   messages: ChatMessage[];
   inputValue: string;
   onInputChange: (value: string) => void;
-  onSendMessage: () => void;
+  onAIRequest: (type: "aiRequest" | "chat") => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   onSetIsComposing: (isComposing: boolean) => void;
 }
@@ -20,7 +20,7 @@ export const RightPanel = ({
   messages,
   inputValue,
   onInputChange,
-  onSendMessage,
+  onAIRequest,
   onKeyDown,
   onSetIsComposing,
 }: RightPanelProps) => {
@@ -82,7 +82,7 @@ export const RightPanel = ({
             className="flex-1"
           />
           <Button
-            onClick={onSendMessage}
+            onClick={() => onAIRequest("aiRequest")}
             disabled={!inputValue.trim()}
             className="bg-accent text-accent-foreground hover:bg-accent/90"
           >


### PR DESCRIPTION
### 📃 Changes
* Pressing Enter sends a "chat" message
* Clicking the AI button sends an "aiRequest" message
* Added imgUrl to ChatMessage type for avatar support
* Styled messages by type:
    * chat: default
    * aiRequest: yellow
    * aiResponse: blue
* Updated avatar logic: current user vs others
* Changed send button icon from Send to BotIcon
* Updated helper text: “Press Enter to send a message, click the button to ask AI”

### 📌 Important
* Chat input handling is now type-based: "chat" vs "aiRequest"
* imgUrl enables future support for user profile image display in group chats
* Message rendering is now visually distinguished based on the message type

### 🫨 Considerations
* If accessToken is missing, ChatMessageCard returns null to avoid render errors
* AI responses are assumed to follow the "aiResponse" type and may require backend adjustments for consistency
* Future types (e.g. system, error, command) can easily be supported through existing message styling logic

### 🎇 Screenshots
<img width="1582" alt="스크린샷 2025-05-16 오후 8 48 51" src="https://github.com/user-attachments/assets/e6f552e4-b9dd-4233-9114-ccfe88d9bc24" />

### 💫 ETC
* Unified message handler: handleSendMessage(type)
* RightPanel prop renamed to onAIRequest