### PR TITLE
Refresh pins on WebSocket trigger and ensure unique place dialogs

### DIFF
--- a/src/app/modules/chat/store/websocket-store.ts
+++ b/src/app/modules/chat/store/websocket-store.ts
@@ -5,6 +5,7 @@ type WebSocketStore = {
   socket: WebSocket | null;
   chatMessages: ChatMessage[];
   refreshMapTrigger: number;
+  refreshScheduleTrigger: number;
   connect: (roomId: string, userName: string) => void;
   sendMessage: (type: "chat" | "ai", msg: string) => void;
   addMessage: (message: ChatMessage) => void;
@@ -21,6 +22,7 @@ export const useWebSocketStore = create<WebSocketStore>((set, get) => ({
     },
   ],
   refreshMapTrigger: 0,
+  refreshScheduleTrigger: 0,
 
   connect: (roomId, userName) => {
     if (get().socket) return;
@@ -48,6 +50,12 @@ export const useWebSocketStore = create<WebSocketStore>((set, get) => ({
           case "refreshMap":
             set((state) => ({
               refreshMapTrigger: state.refreshMapTrigger + 1,
+            }));
+            break;
+
+          case "refreshSchedule":
+            set((state) => ({
+              refreshScheduleTrigger: state.refreshScheduleTrigger + 1,
             }));
             break;
 

--- a/src/app/modules/chat/ui/middle-panel.tsx
+++ b/src/app/modules/chat/ui/middle-panel.tsx
@@ -157,12 +157,12 @@ export const MiddlePanel = ({
         <div className="flex-1 overflow-y-auto p-4">
           {filteredPlaces.length > 0 ? (
             <div className="space-y-3">
-              {filteredPlaces.map((place) => (
+              {filteredPlaces.map((place, i) => (
                 <PlaceDialog
-                  key={place.placeId}
+                  key={`place-dialog-${place.placeId}-${i}`}
                   place={place}
                   activePlacesTab={activePlacesTab}
-                // onAddEvent={onAddEvent}
+                  // onAddEvent={onAddEvent}
                 />
               ))}
             </div>

--- a/src/app/modules/map/store/liked-place-store.ts
+++ b/src/app/modules/map/store/liked-place-store.ts
@@ -33,6 +33,7 @@ type LikedPlaceStore = {
   ) => google.maps.marker.AdvancedMarkerElement | undefined;
   setIconType: (placeId: string, iconType: IconType) => void;
   getIconType: (placeId: string) => IconType | undefined;
+  setLikedPlacesNull: () => void;
 };
 
 export const useLikedPlaces = create<LikedPlaceStore>((set, get) => ({
@@ -62,4 +63,8 @@ export const useLikedPlaces = create<LikedPlaceStore>((set, get) => ({
     })),
   getIconType: (placeId) =>
     get().likedPlaces.find((p) => p.placeId === placeId)?.iconType,
+  setLikedPlacesNull: () =>
+    set(() => ({
+      likedPlaces: [],
+    })),
 }));

--- a/src/app/modules/map/ui/components/google-map.tsx
+++ b/src/app/modules/map/ui/components/google-map.tsx
@@ -9,6 +9,7 @@ import { useApi } from "@/hooks/use-api";
 import { IconType, useLikedPlaces } from "../../store/liked-place-store";
 import { useAuthStore } from "@/store/auth-store";
 import { parseJwt } from "@/lib/parseJwt";
+import { useWebSocketStore } from "@/app/modules/chat/store/websocket-store";
 
 interface MapConfigResponse {
   id: number;
@@ -43,11 +44,17 @@ export function GoogleMap() {
   const setMap = useMapStore((state) => state.setMap);
   const googleMaps = useMapStore((state) => state.googleMaps);
   const setGoogleMaps = useMapStore((state) => state.setGoogleMaps);
+  const refreshMapTrigger = useWebSocketStore(
+    (state) => state.refreshMapTrigger
+  );
   const searchParams = useSearchParams();
 
   const chatRoomId = searchParams.get("id");
   const addPlace = useLikedPlaces((state) => state.addPlace);
   const setMarker = useLikedPlaces((state) => state.setMarker);
+  const setLikedPlacesNull = useLikedPlaces(
+    (state) => state.setLikedPlacesNull
+  );
 
   const accessToken = useAuthStore((s) => s.accessToken);
   if (!accessToken) return null;
@@ -130,6 +137,8 @@ export function GoogleMap() {
         }
       });
 
+      setLikedPlacesNull();
+
       mapConfig.pins.forEach((pin) => {
         const img = document.createElement("img");
         img.src = pin.iconType === IconType.HEART ? "/heart.png" : "/star.png";
@@ -163,7 +172,7 @@ export function GoogleMap() {
     };
 
     initMap();
-  }, [searchParams]);
+  }, [searchParams, refreshMapTrigger]);
 
   return (
     <div className="relative w-full h-full">


### PR DESCRIPTION
### 📃 Changes

- **WebSocketStore**
  - Added `refreshScheduleTrigger` for future calendar sync support
  - Handled new WebSocket message type: `"refreshSchedule"`
- **MiddlePanel**
  - Updated `PlaceDialog` component key to include index  
    `key={`place-dialog-${place.placeId}-${i}`}`  
    → Prevents React reusing the same component instance
- **LikedPlaceStore**
  - Added `setLikedPlacesNull()` to reset all liked places
- **GoogleMap**
  - Subscribed to `refreshMapTrigger` from WebSocket store
  - Called `setLikedPlacesNull()` before applying new pins  
    → Avoids duplicated markers
  - Updated `useEffect` dependencies to `[searchParams, refreshMapTrigger]`

### 📌 Important

- Prevented duplicate pin rendering by clearing store before re-adding
- Map now reacts to real-time `"refreshMap"` messages

### 🫨 Considerations

- `refreshScheduleTrigger` is defined but unused (reserved for future features)
- Be cautious when clearing liked places, may affect UI or other components

### 🎇 Screenshots

### 💫 ETC

- Retained `console.log` in map for dev debugging
- Consider throttling map updates if frequent refreshes occur